### PR TITLE
define getSyncMethod locally so it doesn't get clobbered by other Backbone modules

### DIFF
--- a/backbone.dropboxDatastore.js
+++ b/backbone.dropboxDatastore.js
@@ -250,7 +250,7 @@
 
   Backbone.originalSync = Backbone.sync;
 
-  Backbone.getSyncMethod = function(model) {
+  function getSyncMethod(model) {
     if(model.dropboxDatastore || (model.collection && model.collection.dropboxDatastore)) {
       return Backbone.DropboxDatastore.sync;
     } else {
@@ -261,7 +261,7 @@
   // Override 'Backbone.sync' to default to dropboxDatastoreSync,
   // the original 'Backbone.sync' is still available in 'Backbone.originalSync'
   Backbone.sync = function(method, model, options) {
-    return Backbone.getSyncMethod(model).call(this, method, model, options);
+    return getSyncMethod(model).call(this, method, model, options);
   };
 
   return Backbone.DropboxDatastore;


### PR DESCRIPTION
I'm using Backbone.dropboxDatastore and Backbone.localStorage on the same page. They both define `Backbone.getSyncMethod` which causes `Backbone.sync` to enter an infinite loop. This patch makes `getSyncMethod` a local function so that doesn't happen. A similar patch may need to be applied to Backbone.localStorage (I haven't tried without also making the change there yet).
